### PR TITLE
Added sync committee methods, some bugfixes

### DIFF
--- a/src/dvspec/consensus.py
+++ b/src/dvspec/consensus.py
@@ -1,4 +1,4 @@
-from eth2spec.phase0.altair import (
+from eth2spec.altair.mainnet import (
     AttestationData,
     BeaconBlock,
 )
@@ -7,6 +7,8 @@ from .utils.types import (
     AttestationDuty,
     ProposerDuty,
     SlashingDB,
+    SyncCommitteeDuty,
+    SyncCommitteeContribution,
 )
 from .utils.helpers import (
     is_slashable_attestation_data,
@@ -53,6 +55,24 @@ def consensus_on_block(slashing_db: SlashingDB, proposer_duty: ProposerDuty) -> 
     Returns the decided value.
     If this DV is the leader, it must use `bn_produce_block` for the proposed value.
     The consensus protocol must use `consensus_is_valid_block` to determine
+    validity of the proposed block value.
+    """
+    pass
+
+
+# TODO: Does sync committee contribution need slashing DB?
+def consensus_is_valid_sync_committee_contribution(sync_committee_contribution: SyncCommitteeContribution,
+                                                   sync_committee_duty: SyncCommitteeDuty) -> bool:
+    """Determines if the given sync committee contribution is valid for the sync committee duty.
+    """
+    pass
+
+
+def consensus_on_sync_committee_contribution(sync_committee_duty: SyncCommitteeDuty) -> SyncCommitteeContribution:
+    """Consensus protocol between distributed validator nodes for sync committee contribution values.
+    Returns the decided value.
+    If this DV is the leader, it must use `bn_produce_sync_committee_contribution` for the proposed value.
+    The consensus protocol must use `consensus_is_valid_sync_committee_contribution` to determine
     validity of the proposed block value.
     """
     pass

--- a/src/dvspec/eth_node_interface.py
+++ b/src/dvspec/eth_node_interface.py
@@ -1,5 +1,5 @@
 from typing import List
-from eth2spec.phase0.altair import (
+from eth2spec.altair.mainnet import (
     Attestation,
     AttestationData,
     BeaconBlock,
@@ -8,7 +8,8 @@ from eth2spec.phase0.altair import (
 
 from .networking import (
     broadcast_threshold_signed_attestation,
-    broadcast_threshold_signed_block
+    broadcast_threshold_signed_block,
+    broadcast_threshold_signed_sync_committee_signature,
 )
 from .utils.types import (
     AttestationDuty,
@@ -51,8 +52,8 @@ def bn_submit_attestation(attestation: Attestation) -> None:
     pass
 
 
-def bn_get_proposer_duties_for_epoch(validator_indices: List[ValidatorIndex], epoch: Epoch) -> List[ProposerDuty]:
-    """Fetch proposer duties for the supplied validators in the epoch.
+def bn_get_proposer_duties_for_epoch(epoch: Epoch) -> List[ProposerDuty]:
+    """Fetch proposer duties for all proposers in the epoch.
     Uses https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/getProposerDuties
     """
     pass
@@ -89,7 +90,7 @@ def bn_produce_sync_committee_contribution(slot: Slot,
     pass
 
 
-def bn_submit_sync_committee_signatures(sync_committee_signatures: List[SyncCommitteeSignature]) -> None:
+def bn_submit_sync_committee_signature(sync_committee_signature: SyncCommitteeSignature) -> None:
     """Submit sync committee signatures to the BN for Ethereum p2p gossip.
     Uses https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/submitPoolSyncCommitteeSignatures
     """
@@ -129,6 +130,14 @@ def cache_block_for_vc(block: BeaconBlock, proposer_duty: ProposerDuty) -> None:
     pass
 
 
+def cache_sync_committee_contribution_for_vc(sync_committee_contribution: SyncCommitteeContribution,
+                                             sync_committee_duty: SyncCommitteeDuty) -> None:
+    """Cache sync committee contribution to provide to VC when it seeks new data using the following method:
+    https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/produceSyncCommitteeContribution
+    """
+    pass
+
+
 def capture_threshold_signed_attestation(threshold_signed_attestation: Attestation) -> None:
     """Captures a threshold signed attestation provided by the VC and starts the recombination process to
     construct a complete signed attestation to submit to the BN. The VC submits the attestation using the
@@ -143,3 +152,12 @@ def capture_threshold_signed_block(threshold_signed_block: SignedBeaconBlock) ->
     https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/publishBlock
     """
     broadcast_threshold_signed_block(threshold_signed_block)
+
+
+def capture_threshold_signed_sync_committee_signature(
+        threshold_signed_sync_committee_signature: SyncCommitteeSignature) -> None:
+    """Captures a threshold signed block provided by the VC and starts the recombination process to
+    construct a complete signed block to submit to the BN. The VC submits the block using the following method:
+    https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/publishBlock
+    """
+    broadcast_threshold_signed_sync_committee_signature(threshold_signed_sync_committee_signature)

--- a/src/dvspec/networking.py
+++ b/src/dvspec/networking.py
@@ -1,6 +1,10 @@
 from typing import List
 
-from eth2spec.phase0.altair import Attestation, SignedBeaconBlock
+from eth2spec.altair.mainnet import Attestation, SignedBeaconBlock
+
+from .utils.types import (
+    SyncCommitteeSignature,
+)
 
 """
 Networking Specification
@@ -21,7 +25,7 @@ def listen_for_threshold_signed_attestations() -> List[Attestation]:
 
 
 def construct_signed_attestation(threshold_signed_attestations: List[Attestation]) -> Attestation:
-    """Broadcasts a threshold signed attestation among DV peer nodes.
+    """Construct a complete signed attestation from threshold signed attestations.
     """
     pass
 
@@ -40,6 +44,27 @@ def listen_for_threshold_signed_blocks() -> List[SignedBeaconBlock]:
 
 
 def construct_signed_block(threshold_signed_blocks: List[SignedBeaconBlock]) -> SignedBeaconBlock:
-    """Broadcasts a threshold signed beacon block among DV peer nodes.
+    """Construct a complete signed block from threshold signed blocks.
+    """
+    pass
+
+
+def broadcast_threshold_signed_sync_committee_signature(
+        threshold_signed_sync_committee_signature: SyncCommitteeSignature) -> None:
+    """Broadcasts a threshold signed sync committee signature among DV peer nodes.
+    """
+    pass
+
+
+def listen_for_threshold_signed_sync_committee_signatures() -> List[SyncCommitteeSignature]:
+    """Returns a list of any threshold signed sync committee signatures that can be combined to construct
+    a complete signed block.
+    """
+    pass
+
+
+def construct_signed_sync_committee_signature(
+        threshold_signed_sync_committee_signatures: List[SyncCommitteeSignature]) -> SyncCommitteeSignature:
+    """Construct a complete signed sync committee signature from threshold signed sync committee signatures.
     """
     pass

--- a/src/dvspec/spec.py
+++ b/src/dvspec/spec.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import (
     List,
 )
-from eth2spec.phase0.altair import (
+from eth2spec.altair.mainnet import (
     AttestationData,
     BeaconBlock,
 )
@@ -15,20 +15,26 @@ from .utils.helpers import (
 from .eth_node_interface import (
     AttestationDuty,
     ProposerDuty,
+    SyncCommitteeDuty,
     bn_submit_attestation,
     bn_submit_block,
+    bn_submit_sync_committee_signature,
     cache_attestation_data_for_vc,
     cache_block_for_vc,
+    cache_sync_committee_contribution_for_vc,
 )
 from .consensus import (
     consensus_on_attestation,
     consensus_on_block,
+    consensus_on_sync_committee_contribution,
 )
 from .networking import (
     construct_signed_attestation,
     construct_signed_block,
+    construct_signed_sync_committee_signature,
     listen_for_threshold_signed_attestations,
-    listen_for_threshold_signed_blocks
+    listen_for_threshold_signed_blocks,
+    listen_for_threshold_signed_sync_committee_signatures,
 )
 from .utils.types import (
     BLSPubkey,
@@ -142,6 +148,22 @@ def serve_proposer_duty(slashing_db: SlashingDB, proposer_duty: ProposerDuty) ->
     cache_block_for_vc(block, proposer_duty)
 
 
+def serve_sync_committee_duty(slashing_db: SlashingDB, sync_committee_duty: SyncCommitteeDuty) -> None:
+    """"
+    Sync Committee Signature Production Process:
+    TODO: What is the sequence here - do you query for next epoch's duties?
+    """
+    # TODO: Is lock on consensus the best way to do this?
+    # Obtain lock on consensus_on_sync_committee_contribution here.
+    # Only a single consensus_on_sync_committee_contribution instance should be
+    # running at any given time
+    sync_committee_contribution = consensus_on_sync_committee_contribution(sync_committee_duty)
+    # Release lock on consensus_on_block here.
+    # TODO: Update slashing DB with sync committee contribution
+    # Cache decided sync committee contribution value to provide to VC
+    cache_sync_committee_contribution_for_vc(sync_committee_contribution, sync_committee_duty)
+
+
 def threshold_attestation_combination() -> None:
     """
     Threshold Attestation Combination Process:
@@ -174,3 +196,23 @@ def threshold_signed_block_combination() -> None:
     complete_signed_block = construct_signed_block(threshold_signed_blocks)
     # 3. Send to beacon node for gossip
     bn_submit_block(complete_signed_block)
+
+
+def threshold_signed_sync_committee_signature_combination() -> None:
+    """
+    Threshold Sync Committee Signature Combination Process:
+    1. Always keep listening for threshold signed sync committee signatures using
+        listen_for_threshold_signed_sync_committee_signatures.
+    2a. Whenever a set of threshold signed sync committee signatures are found in Step 1 that can be
+        combined to construct a complete signed sync committee signature, construct the sync committee
+        signature.
+    2b. Send the sync committee signature to the beacon node for Ethereum p2p gossip.
+    """
+    # 1. Always listen for threshold signed sync committee signatures from DV peers.
+    threshold_signed_sync_committee_signatures = listen_for_threshold_signed_sync_committee_signatures()
+    # 2. Reconstruct complete signed sync committee signature by combining threshold
+    #    signed sync committee signatures
+    complete_signed_sync_committee_signature = \
+        construct_signed_sync_committee_signature(threshold_signed_sync_committee_signatures)
+    # 3. Send to beacon node for gossip
+    bn_submit_sync_committee_signature(complete_signed_sync_committee_signature)

--- a/src/dvspec/utils/helpers.py
+++ b/src/dvspec/utils/helpers.py
@@ -1,5 +1,5 @@
-import eth2spec.phase0.altair as eth2spec
-from eth2spec.phase0.altair import (
+import eth2spec.altair.mainnet as eth2spec
+from eth2spec.altair.mainnet import (
     AttestationData,
     BeaconBlock,
 )

--- a/tests/helpers/consensus.py
+++ b/tests/helpers/consensus.py
@@ -1,4 +1,4 @@
-from eth2spec.phase0.altair import (
+from eth2spec.altair.mainnet import (
     AttestationData,
     BeaconBlock,
 )

--- a/tests/helpers/eth_node_interface.py
+++ b/tests/helpers/eth_node_interface.py
@@ -1,5 +1,5 @@
 import random
-from eth2spec.phase0.altair import (
+from eth2spec.altair.mainnet import (
     MAX_COMMITTEES_PER_SLOT,
     SLOTS_PER_EPOCH,
     TARGET_COMMITTEE_SIZE,

--- a/tests/helpers/time.py
+++ b/tests/helpers/time.py
@@ -1,7 +1,7 @@
 from typing import (
     Iterator,
 )
-from eth2spec.phase0.altair import (
+from eth2spec.altair.mainnet import (
     SLOTS_PER_EPOCH,
     config,
 )


### PR DESCRIPTION
- Replace import `eth2spec.phase0.altair` with `eth2spec.altair.mainnet`
- Define relevant sync committee methods for DVC spec, consensus, VC interface, and DVC networking