### PR TITLE
Remove asserts from consensus validity checks

### DIFF
--- a/src/dvspec/consensus.py
+++ b/src/dvspec/consensus.py
@@ -25,10 +25,11 @@ def consensus_is_valid_attestation_data(slashing_db: SlashingDB,
                                         attestation_data: AttestationData, attestation_duty: AttestationDuty) -> bool:
     """Determines if the given attestation is valid for the attestation duty.
     """
-    assert attestation_data.slot == attestation_duty.slot
-    assert attestation_data.index == attestation_duty.committee_index
-    assert not is_slashable_attestation_data(slashing_db, attestation_data, attestation_duty.pubkey)
-    return True
+    return \
+        attestation_data.slot == attestation_duty.slot and \
+        attestation_data.index == attestation_duty.committee_index and \
+        not is_slashable_attestation_data(slashing_db, attestation_data, attestation_duty.pubkey)
+
 
 
 def consensus_on_attestation(slashing_db: SlashingDB, attestation_duty: AttestationDuty) -> AttestationData:
@@ -44,10 +45,9 @@ def consensus_on_attestation(slashing_db: SlashingDB, attestation_duty: Attestat
 def consensus_is_valid_block(slashing_db: SlashingDB, block: BeaconBlock, proposer_duty: ProposerDuty) -> bool:
     """Determines if the given block is valid for the proposer duty.
     """
-    assert block.slot == proposer_duty.slot
-    # TODO: Assert correct block.proposer_index
-    assert not is_slashable_block(slashing_db, block, proposer_duty.pubkey)
-    return True
+     # TODO: Add correct block.proposer_index check \ 
+    return block.slot == proposer_duty.slot and \
+           not is_slashable_block(slashing_db, block, proposer_duty.pubkey)
 
 
 def consensus_on_block(slashing_db: SlashingDB, proposer_duty: ProposerDuty) -> AttestationData:


### PR DESCRIPTION
It is admissible that `consensus_is_valid_attestation_data` and `consensus_is_valid_block` are called with values that do not meet all the current assert statements as these functions are intended to be used by the consensus engine to check whether a piece of data is valid. If the data is valid `True` should be returned. Otherwise, `false` should be returned rather than ending up with an assert failure.

This PR applies the fix described above.