### PR TITLE
Use a less restrictive formula to calculate the required threshold size.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This specification presents a way to implement Distributed Validator Client soft
 ### Assumptions
 - We assume *N* total nodes and an *M-of-N* threshold signature scheme.
     - For general compatibility with BFT consensus protocols, we assume that `M = ((2 * N - 1) / 3) + 1`.
-- This specification assumes [some leader-based safety-favoring consensus protocol](src/dvspec/consensus.py) for the Co-Validators to decide on signing upon the same attestation/block. We assume that the consensus protocol runs successfully with *M* correct nodes out of *N* total nodes.
+- This specification assumes [some leader-based safety-favoring consensus protocol](src/dvspec/consensus.py) for the Co-Validators to decide on signing upon the same attestation/block. We assume that the consensus protocol runs successfully with *M* correct nodes, no more than `F = (N-1)/3` Byzantine nodes and no more than `N - M - F` fail-stop nodes out of *N* total nodes.
 - We assume the usual prerequisites for safe operation of the Validator Client, such as an up-to-date anti-slashing database, correct system clock, etc.
 - We disregard the voting on the "correct" Ethereum fork for now - this functionality will be added in a future update.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This specification presents a way to implement Distributed Validator Client soft
 
 ### Assumptions
 - We assume *N* total nodes and an *M-of-N* threshold signature scheme.
-    - For general compatibility with BFT consensus protocols, we assume that `M = (2 * N / 3) + 1`.
+    - For general compatibility with BFT consensus protocols, we assume that `M = ((2 * N - 1) / 3) + 1`.
 - This specification assumes [some leader-based safety-favoring consensus protocol](src/dvspec/consensus.py) for the Co-Validators to decide on signing upon the same attestation/block. We assume that the consensus protocol runs successfully with *M* correct nodes out of *N* total nodes.
 - We assume the usual prerequisites for safe operation of the Validator Client, such as an up-to-date anti-slashing database, correct system clock, etc.
 - We disregard the voting on the "correct" Ethereum fork for now - this functionality will be added in a future update.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This specification presents a way to implement Distributed Validator Client soft
 
 ### Assumptions
 - We assume *N* total nodes and an *M-of-N* threshold signature scheme.
-    - For general compatibility with BFT consensus protocols, we assume that `M = ((2 * N - 1) / 3) + 1`.
+    - For general compatibility with BFT consensus protocols, we assume that `M = ceil(2 * N / 3)`.
 - This specification assumes [some leader-based safety-favoring consensus protocol](src/dvspec/consensus.py) for the Co-Validators to decide on signing upon the same attestation/block. We assume that the consensus protocol runs successfully with *M* correct nodes, no more than `F = (N-1)/3` Byzantine nodes and no more than `N - M - F` fail-stop nodes out of *N* total nodes.
 - We assume the usual prerequisites for safe operation of the Validator Client, such as an up-to-date anti-slashing database, correct system clock, etc.
 - We disregard the voting on the "correct" Ethereum fork for now - this functionality will be added in a future update.


### PR DESCRIPTION
The formula `M = ceil(2 * N / 3)`, which is equivalent to `M = ((2 * N - 1) / 3) + 1`, provides a better bound on the size of the required threshold than `M = ceil(2 * N / 3) + 1`.
For example, in the case of `N  = 6`, `M` can safely be set to 4 rather than 5, i.e. with `N = 6`, we admit 1 Byz node + 1 fail-stop node.

